### PR TITLE
fix: resolve NXM handoff timeout and improve download reliability

### DIFF
--- a/core/api/server.py
+++ b/core/api/server.py
@@ -2079,17 +2079,8 @@ def submit_nxm_handoff(payload: Optional[Dict[str, Any]] = Body(default=None)) -
 	if not isinstance(nxm_value, str) or not nxm_value.strip():
 		raise HTTPException(status_code=400, detail="nxm field is required")
 	
-	# DEBUG: Log the exact URL received
-	logger.info("[NXM DEBUG] ===== RECEIVED NXM URL =====")
-	logger.info("[NXM DEBUG] Full URL: %s", nxm_value)
-	logger.info("[NXM DEBUG] URL length: %d", len(nxm_value))
-	logger.info("[NXM DEBUG] Contains '?': %s", "?" in nxm_value)
-	logger.info("[NXM DEBUG] Contains '&': %s", "&" in nxm_value)
-	if "?" in nxm_value:
-		query_part = nxm_value.split("?", 1)[1] if "?" in nxm_value else ""
-		logger.info("[NXM DEBUG] Query string: %s", query_part)
-	logger.info("[NXM DEBUG] =============================")
-	
+	logger.info("[nxm_handoff] received NXM URL length=%d", len(nxm_value))
+
 	# Store the last received NXM URL for testing/debugging
 	_LAST_NXM_URL = {
 		"url": nxm_value,
@@ -2265,6 +2256,8 @@ def _find_matching_handoff(
 	"""
 	candidates: List[Dict[str, Any]] = []
 	for record in list_handoffs():
+		if record.get("consumed"):
+			continue
 		req = record.get("request") or {}
 		req_mod_id = _coerce_int(req.get("mod_id"))
 		if req_mod_id != mod_id:
@@ -2443,28 +2436,21 @@ def check_mod_update(mod_id: int) -> Dict[str, Any]:
 
 @app.post("/api/nxm/handoff/{handoff_id}/ingest")
 def ingest_nxm_handoff(handoff_id: str, payload: Optional[Dict[str, Any]] = Body(default=None)) -> Dict[str, Any]:
-	import sys
-	print(f"\n{'='*80}", file=sys.stderr)
-	print(f"[INGEST START] Handoff ID: {handoff_id}", file=sys.stderr)
-	print(f"[INGEST START] Payload: {payload}", file=sys.stderr)
-	print(f"{'='*80}\n", file=sys.stderr)
-	
 	if not handoff_id:
 		raise HTTPException(status_code=400, detail="handoff_id is required")
-	
+
+	logger.info("[nxm_handoff] ingest start handoff_id=%s payload_keys=%s", handoff_id, list((payload or {}).keys()))
+
 	# Circuit breaker: Check if this handoff should be skipped due to repeated failures
 	should_skip, skip_reason = should_skip_handoff(handoff_id)
 	if should_skip:
-		logger.warning(f"[nxm_handoff] Skipping handoff {handoff_id}: {skip_reason}")
+		logger.warning("[nxm_handoff] Skipping handoff %s: %s", handoff_id, skip_reason)
 		raise HTTPException(status_code=429, detail=f"Too many failed attempts. {skip_reason}")
-	
-	print(f"[INGEST] Fetching handoff record...", file=sys.stderr)
+
 	record = get_handoff_or_404(handoff_id)
 	handoff_identifier = record.get("id") if isinstance(record.get("id"), str) else None
-	print(f"[INGEST] Handoff record fetched: {handoff_identifier}", file=sys.stderr)
-	
+
 	# Early API key validation to prevent wasted processing
-	print(f"[INGEST] Checking API key...", file=sys.stderr)
 	api_key = get_api_key()
 	if not api_key:
 		error_msg = "NEXUS_API_KEY not configured. Please add your Nexus Mods API key in Settings."
@@ -2562,39 +2548,22 @@ def ingest_nxm_handoff(handoff_id: str, payload: Optional[Dict[str, Any]] = Body
 			created_at_hint=file_created_at_hint,
 		)
 	except DuplicateDownloadError as exc:
-		try:
-			import traceback
-			import sys
-			print(f"[ingest_debug] DuplicateDownloadError caught: {exc}", file=sys.stderr)
-			if handoff_identifier:
-				update_handoff_progress(
-					handoff_identifier,
-					stage="failed",
-					error=str(exc),
-					message="Duplicate download detected",
-				)
-				register_handoff_failure(handoff_identifier, str(exc))
-				# Mark as consumed to prevent infinite retry loops on frontend restart
-				print(f"[ingest_debug] Marking handoff {handoff_identifier} as consumed", file=sys.stderr)
-				mark_handoff_consumed(handoff_identifier)
-			
-			print(f"[ingest_debug] Generating detail from error", file=sys.stderr)
-			detail = _duplicate_detail_from_error(exc)
-			print(f"[ingest_debug] Raising 409", file=sys.stderr)
-			raise HTTPException(status_code=409, detail=detail)
-		except HTTPException:
-			raise
-			# ... (duplicate block maintained)
-			raise HTTPException(status_code=409, detail=detail)
+		logger.info("[nxm_handoff] DuplicateDownloadError handoff=%s: %s", handoff_identifier, exc)
+		if handoff_identifier:
+			update_handoff_progress(
+				handoff_identifier,
+				stage="failed",
+				error=str(exc),
+				message="Duplicate download detected",
+			)
+			register_handoff_failure(handoff_identifier, str(exc))
+			mark_handoff_consumed(handoff_identifier)
+		detail = _duplicate_detail_from_error(exc)
+		raise HTTPException(status_code=409, detail=detail)
 	except HTTPException:
 		raise
 	except Exception as e:
-		# Graceful error handling for fatal errors
-		import traceback
-		import sys
-		print(f"[ingest_debug] ERROR during ingestion: {e}", file=sys.stderr)
-		traceback.print_exc(file=sys.stderr)
-		
+		logger.exception("[nxm_handoff] ingestion failed handoff=%s", handoff_identifier)
 		if handoff_identifier:
 			register_handoff_failure(handoff_identifier, str(e))
 			update_handoff_progress(
@@ -2603,13 +2572,7 @@ def ingest_nxm_handoff(handoff_id: str, payload: Optional[Dict[str, Any]] = Body
 				error=str(e),
 				message="Ingestion Failed"
 			)
-			# Force consume handoff on fatal error to prevent infinite restart loops
-			# If it failed this badly, retrying the same handoff is likely futile
-			print(f"[ingest_debug] Marking handoff {handoff_identifier} as consumed due to fatal error", file=sys.stderr)
 			mark_handoff_consumed(handoff_identifier)
-			
-		# Return 400 instead of 500 to ensure frontend receives the error detail
-		# and to avoid partial CORS issues with 500s
 		raise HTTPException(status_code=400, detail=f"Ingestion failed: {str(e)}")
 	new_download_id = ingest_result.get("download_id")
 	if not isinstance(new_download_id, int):
@@ -4590,12 +4553,6 @@ def _resolve_nexus_download_candidates(
 	expires = str(query.get("expires") or metadata.get("expires") or "").strip()
 	user_id = str(query.get("user_id") or "").strip()
 	
-	# DEBUG: Log what we extracted
-	logger.info("[NXM DEBUG] Extracted from URL - key: %s, expires: %s, user_id: %s", 
-		"(present)" if key else "(MISSING)", 
-		"(present)" if expires else "(MISSING)", 
-		"(present)" if user_id else "(MISSING)")
-	
 	if not key or not expires:
 		error_msg = (
 			"NXM download authorization missing or expired. "
@@ -4603,7 +4560,7 @@ def _resolve_nexus_download_candidates(
 			"then click 'Download with Manager' button again. "
 			f"(key={'present' if key else 'MISSING'}, expires={'present' if expires else 'MISSING'})"
 		)
-		logger.error("[NXM DEBUG] %s", error_msg)
+		logger.warning("[nxm_handoff] authorization missing key=%s expires=%s", bool(key), bool(expires))
 		raise HTTPException(status_code=400, detail=error_msg)
 	domain = (game_domain or DEFAULT_GAME or "marvelrivals").strip().lower() or DEFAULT_GAME
 	params = {"key": key, "expires": expires}

--- a/core/api/server.py
+++ b/core/api/server.py
@@ -4580,7 +4580,7 @@ def _resolve_nexus_download_candidates(
 	if api_key:
 		headers["apikey"] = api_key
 		headers["Application-Name"] = "MarvelRivalsModManager"
-		headers["Application-Version"] = "0.3.2"
+		headers["Application-Version"] = "0.3.3"
 	req = urllib.request.Request(api_url, headers=headers, method="GET")
 	try:
 		with urllib.request.urlopen(req, timeout=30) as resp:

--- a/core/api/services/handoffs.py
+++ b/core/api/services/handoffs.py
@@ -87,10 +87,12 @@ def get_handoff_or_404(handoff_id: str) -> Dict[str, Any]:
         return record
 
 
-def list_handoffs() -> List[Dict[str, Any]]:
+def list_handoffs(*, include_consumed: bool = False) -> List[Dict[str, Any]]:
     with _HANDOFF_LOCK:
         _purge_expired_locked()
-        return list(_HANDOFFS.values())
+        if include_consumed:
+            return list(_HANDOFFS.values())
+        return [r for r in _HANDOFFS.values() if not r.get("consumed")]
 
 
 def delete_handoff(handoff_id: str) -> Dict[str, Any]:
@@ -151,6 +153,7 @@ def serialize_handoff(record: Dict[str, Any], *, include_metadata: bool = False)
         "created_at": record.get("created_at"),
         "expires_at": record.get("expires_at"),
         "request": record.get("request"),
+        "consumed": bool(record.get("consumed")),
     }
     progress = record.get("progress")
     if isinstance(progress, dict) and progress:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rivalnxt",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "dependencies": {
     "@bbob/preset": "^4.3.1",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "RivalNxt",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "identifier": "com.rivalnxt.modmanager",
   "build": {
     "beforeDevCommand": "yarn --cwd .. dev",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -814,7 +814,9 @@ export default function App() {
               // Remove tracking on timeout
               updateManagedPairsRef.current.delete(trackingKey);
               throw new Error(
-                "Timed out waiting for the RivalNxt download handoff."
+                "Timed out waiting for the download handoff. " +
+                "Please make sure you clicked 'Mod Manager Download' on the Nexus Mods page " +
+                "and that RivalNxt is set as your default mod manager in your browser."
               );
             }
 

--- a/src/components/NxmBackgroundListener.tsx
+++ b/src/components/NxmBackgroundListener.tsx
@@ -64,8 +64,8 @@ export function NxmBackgroundListener({
         let hasWork = false;
 
         for (const handoff of handoffs) {
-          // Skip if already successfully processed
-          if (processedHandoffsRef.current.has(handoff.id)) {
+          // Skip if already successfully processed or consumed by backend
+          if (processedHandoffsRef.current.has(handoff.id) || handoff.consumed) {
             continue;
           }
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -96,6 +96,7 @@ export type ApiNxmHandoffSummary = {
   id: string;
   created_at?: number | null;
   expires_at?: number | null;
+  consumed?: boolean;
   request?: {
     raw?: string;
     game?: string;

--- a/src/lib/nxmHelpers.ts
+++ b/src/lib/nxmHelpers.ts
@@ -10,7 +10,6 @@ import {
 
 export type WaitForHandoffOptions = {
   timeoutMs?: number;
-  intervalMs?: number;
 };
 
 export function formatBytes(size?: number | null): string {
@@ -43,41 +42,61 @@ export async function waitForMatchingHandoff(
   fileId: number | null,
   options: WaitForHandoffOptions = {}
 ): Promise<ApiNxmHandoffSummary | null> {
-  const timeoutMs = options.timeoutMs ?? 45_000;
-  const intervalMs = options.intervalMs ?? 1_500;
+  const timeoutMs = options.timeoutMs ?? 90_000;
   const deadline = Date.now() + timeoutMs;
 
-  while (Date.now() < deadline) {
+  const tryFindMatch = async (): Promise<ApiNxmHandoffSummary | null> => {
     let handoffs: ApiNxmHandoffSummary[] = [];
     try {
       handoffs = await listNxmHandoffs();
     } catch (err) {
       console.warn("Failed to list Nexus handoffs", err);
+      return null;
     }
+    if (handoffs.length === 0) return null;
 
-    if (handoffs.length > 0) {
-      const matches = handoffs.filter((handoff) => {
-        const request = handoff.request;
-        const requestModId = parseNumber(request?.mod_id);
-        if (requestModId !== modId) return false;
-        if (fileId == null) return true;
-        const requestFileId = parseNumber(request?.file_id);
-        if (requestFileId == null) return false;
-        return requestFileId === fileId;
-      });
+    const matches = handoffs.filter((handoff) => {
+      if (handoff.consumed) return false;
+      const request = handoff.request;
+      const requestModId = parseNumber(request?.mod_id);
+      if (requestModId !== modId) return false;
+      if (fileId == null) return true;
+      const requestFileId = parseNumber(request?.file_id);
+      if (requestFileId == null) return false;
+      return requestFileId === fileId;
+    });
 
-      if (matches.length > 0) {
-        const sorted = [...matches].sort(
-          (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
-        );
-        return sorted[0];
-      }
+    if (matches.length === 0) return null;
+    const sorted = [...matches].sort(
+      (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
+    );
+    return sorted[0];
+  };
+
+  // Adaptive polling: slow at start (user is switching to browser),
+  // faster in the middle, rapid near the deadline to avoid near-misses.
+  while (Date.now() < deadline) {
+    const match = await tryFindMatch();
+    if (match) return match;
+
+    const remaining = deadline - Date.now();
+    let intervalMs: number;
+    if (remaining > 60_000) {
+      // First ~30s: user is loading the Nexus page — poll every 2.5s
+      intervalMs = 2_500;
+    } else if (remaining > 15_000) {
+      // Middle phase: user likely clicking soon — poll every 1.5s
+      intervalMs = 1_500;
+    } else {
+      // Final 15s: rapid polling to catch near-miss handoffs
+      intervalMs = 750;
     }
-
     await new Promise<void>((resolve) => setTimeout(resolve, intervalMs));
   }
 
-  return null;
+  // One final grace check after the deadline — catches handoffs that arrived
+  // during the last sleep interval.
+  return tryFindMatch();
 }
 
 export type MonitorNxmProgressOptions = {


### PR DESCRIPTION
- Filter consumed handoffs from list_handoffs() and _find_matching_handoff() to prevent stale handoff reuse causing silent failures
- Increase handoff wait timeout from 45s to 90s, giving users realistic time to switch to browser, load Nexus page, and click download
- Use adaptive polling (2.5s -> 1.5s -> 750ms) instead of fixed 1.5s interval, reducing unnecessary backend load early while catching near-miss handoffs at the deadline
- Add final grace poll after deadline to catch last-moment handoffs
- Add consumed field to ApiNxmHandoffSummary type and serialize it from backend so frontend can defensively filter consumed handoffs
- Skip consumed handoffs in NxmBackgroundListener to prevent double-processing
- Replace verbose debug print() statements in ingest endpoint with proper logger calls, removing stderr noise and dead code branches
- Improve timeout error message with actionable troubleshooting steps